### PR TITLE
Updated to Vaadin 14.4, added JDK 8 requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **.iml
 .idea
 **/target
+server/node_modules

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is a simple example application that has (Remote) EJB for Customer entities
 
 ### To play with the demo:
 
+ * Use Java 8 to run the demo
  * build from top level with **mvn install**
  * import the project to your IDE and make one top level build
  * start the server module with **mvn tomee:run** from the module root or by deploying the server module manually to TomEE server configured in you IDE.

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -53,12 +53,12 @@
         <dependency>
             <groupId>org.apache.openejb</groupId>
             <artifactId>openejb-client</artifactId>
-            <version>4.7.1</version>
+            <version>4.7.5</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.10</version>
+            <version>1.7.30</version>
         </dependency>
         <!-- Just to get JPA entities deserialized, strict developers would
              create separate DTOs without JPA annotations
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.apache.openjpa</groupId>
             <artifactId>openjpa</artifactId>
-            <version>2.3.0</version>
+            <version>3.1.2</version>
         </dependency>    
     </dependencies>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -23,7 +23,7 @@
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <deltaspike.version>1.9.0</deltaspike.version>
 
-        <vaadin.version>13.0.6</vaadin.version>
+        <vaadin.version>14.4.4</vaadin.version>
     </properties>
 
     <repositories>
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-app-layout-flow</artifactId>
-            <version>1.1.1</version>
         </dependency>
         <!-- Added to provide logging output as Flow uses -->
         <!-- the unbound SLF4J no-operation (NOP) logger implementation -->
@@ -137,11 +136,58 @@
             <plugin>
                 <groupId>org.apache.tomee.maven</groupId>
                 <artifactId>tomee-maven-plugin</artifactId>
-                <version>8.0.0-M2</version>
+                <version>8.0.4</version>
                 <configuration>
                     <config>${project.basedir}/src/main/resources/tomee/</config>
                 </configuration>
             </plugin>
+                        <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-maven-plugin</artifactId>
+                <version>${vaadin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+    
+        <profiles>
+        <profile>
+            <!-- Production mode is activated using -Pproduction -->
+            <id>production</id>
+            <properties>
+                <vaadin.productionMode>true</vaadin.productionMode>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>flow-server-production-mode</artifactId>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.vaadin</groupId>
+                        <artifactId>vaadin-maven-plugin</artifactId>
+                        <version>${vaadin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>build-frontend</goal>
+                                </goals>
+                                <phase>compile</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
JDK 8 currently needed as jdk rmi libraries are used